### PR TITLE
Add Zod Validation for Chain Events

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -18,11 +18,13 @@
         "axios": "^1.8.2",
         "json-stringify-deterministic": "^1.0.12",
         "nest-winston": "^1.10.2",
+        "nestjs-zod": "^4.3.1",
         "pg": "^8.13.3",
         "reflect-metadata": "^0.2.2",
         "rxjs": "^7.8.1",
         "typeorm": "^0.3.21",
-        "winston": "^3.17.0"
+        "winston": "^3.17.0",
+        "zod": "^3.24.2"
       },
       "devDependencies": {
         "@eslint/eslintrc": "^3.2.0",
@@ -2081,6 +2083,31 @@
       ],
       "engines": {
         "node": ">= 10"
+      }
+    },
+    "node_modules/@nest-zod/z": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/@nest-zod/z/-/z-2.0.0.tgz",
+      "integrity": "sha512-OqmJUZlpcx9ECzPYSIjaR/q/xLKrm9FkV+0FIWLEb9MVc9YeP21GmnQJBxE1dPRlLJ1kybNFBlt4D/PB8YAPkA==",
+      "peerDependencies": {
+        "@nestjs/common": "^10.0.0 || ^11.0.0",
+        "@nestjs/core": "^10.0.0 || ^11.0.0",
+        "@nestjs/swagger": "^7.4.2 || ^8.0.0 || ^11.0.0",
+        "zod": ">= 3.14.3"
+      },
+      "peerDependenciesMeta": {
+        "@nestjs/common": {
+          "optional": true
+        },
+        "@nestjs/core": {
+          "optional": true
+        },
+        "@nestjs/swagger": {
+          "optional": true
+        },
+        "zod": {
+          "optional": false
+        }
       }
     },
     "node_modules/@nestjs/cli": {
@@ -4913,7 +4940,6 @@
       "version": "4.3.1",
       "resolved": "https://registry.npmjs.org/deepmerge/-/deepmerge-4.3.1.tgz",
       "integrity": "sha512-3sUqbMEc77XqpdNO7FRyRog+eW3ph+GYCbj+rK+uYyRMuwsVy0rMiVtPn+QJlKFvWP/1PYpapqYn0Me2knFn+A==",
-      "dev": true,
       "engines": {
         "node": ">=0.10.0"
       }
@@ -8044,6 +8070,35 @@
       "peerDependencies": {
         "@nestjs/common": "^5.0.0 || ^6.6.0 || ^7.0.0 || ^8.0.0 || ^9.0.0 || ^10.0.0 || ^11.0.0",
         "winston": "^3.0.0"
+      }
+    },
+    "node_modules/nestjs-zod": {
+      "version": "4.3.1",
+      "resolved": "https://registry.npmjs.org/nestjs-zod/-/nestjs-zod-4.3.1.tgz",
+      "integrity": "sha512-gl10NOf/AhWt4HLcnMI1J0WUlBCKyteJBftD6SwNyX71/vzAorr5MJQWiDJoPPkou9QL2CRHHBtyjr55o7++Xw==",
+      "dependencies": {
+        "@nest-zod/z": "*",
+        "deepmerge": "^4.3.1"
+      },
+      "peerDependencies": {
+        "@nestjs/common": "^10.0.0 || ^11.0.0",
+        "@nestjs/core": "^10.0.0 || ^11.0.0",
+        "@nestjs/swagger": "^7.4.2 || ^8.0.0 || ^11.0.0",
+        "zod": ">= 3.14.3"
+      },
+      "peerDependenciesMeta": {
+        "@nestjs/common": {
+          "optional": true
+        },
+        "@nestjs/core": {
+          "optional": true
+        },
+        "@nestjs/swagger": {
+          "optional": true
+        },
+        "zod": {
+          "optional": false
+        }
       }
     },
     "node_modules/node-abort-controller": {
@@ -11427,6 +11482,14 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/zod": {
+      "version": "3.24.2",
+      "resolved": "https://registry.npmjs.org/zod/-/zod-3.24.2.tgz",
+      "integrity": "sha512-lY7CDW43ECgW9u1TcT3IoXHflywfVqDYze4waEz812jR/bZ8FHDsl7pFQoSZTz5N+2NqRXs8GBwnAwo3ZNxqhQ==",
+      "funding": {
+        "url": "https://github.com/sponsors/colinhacks"
       }
     }
   }

--- a/package.json
+++ b/package.json
@@ -29,11 +29,13 @@
     "axios": "^1.8.2",
     "json-stringify-deterministic": "^1.0.12",
     "nest-winston": "^1.10.2",
+    "nestjs-zod": "^4.3.1",
     "pg": "^8.13.3",
     "reflect-metadata": "^0.2.2",
     "rxjs": "^7.8.1",
     "typeorm": "^0.3.21",
-    "winston": "^3.17.0"
+    "winston": "^3.17.0",
+    "zod": "^3.24.2"
   },
   "devDependencies": {
     "@eslint/eslintrc": "^3.2.0",

--- a/src/app.module.ts
+++ b/src/app.module.ts
@@ -6,6 +6,8 @@ import { ChainEvent } from './chain-event/entities/chain-event.entity';
 import config, { DBConfig } from './config/config';
 import { LoggerModule } from './logger/logger.module';
 import { ExchangeEventModule } from './exchange-event/exchange-event.module';
+import { APP_PIPE } from '@nestjs/core';
+import { ZodValidationPipe } from 'nestjs-zod';
 
 @Module({
   imports: [
@@ -35,6 +37,11 @@ import { ExchangeEventModule } from './exchange-event/exchange-event.module';
     }),
   ],
   controllers: [],
-  providers: [],
+  providers: [
+    {
+      provide: APP_PIPE,
+      useClass: ZodValidationPipe,
+    },
+  ],
 })
 export class AppModule {}

--- a/src/chain-event/chain-event-sync.service.spec.ts
+++ b/src/chain-event/chain-event-sync.service.spec.ts
@@ -2,7 +2,7 @@ import { Test, TestingModule } from '@nestjs/testing';
 import { ChainEventSyncService } from './chain-event-sync.service';
 import { ChainEventService } from './chain-event.service';
 import { EtherscanService } from './etherscan.service';
-import { ChainEventTransaction } from './types/chain-event';
+import { ChainEventTransaction } from './types/chain-event-transaction';
 import { Logger, InternalServerErrorException } from '@nestjs/common';
 
 describe('ChainEventSyncService', () => {

--- a/src/chain-event/chain-event.controller.spec.ts
+++ b/src/chain-event/chain-event.controller.spec.ts
@@ -93,7 +93,28 @@ describe('ChainEventController', () => {
 
   describe('create', () => {
     it('should create a chain event', async () => {
-      const createDto = {};
+      const createDto = {
+        blockNumber: 12345678,
+        timeStamp: new Date(),
+        transactionHash:
+          '0x1234567890abcdef1234567890abcdef1234567890abcdef1234567890abcdef',
+        nonce: 123,
+        blockHash:
+          '0x1234567890abcdef1234567890abcdef1234567890abcdef1234567890abcdef',
+        from: '0x1234567890abcdef1234567890abcdef12345678',
+        contractAddress: '0x1234567890abcdef1234567890abcdef12345678',
+        to: '0x1234567890abcdef1234567890abcdef12345678',
+        value: '1000000000000000000',
+        tokenName: 'Test Token',
+        tokenSymbol: 'TEST',
+        tokenDecimal: 18,
+        transactionIndex: 1,
+        gas: 21000,
+        gasPrice: '5000000000',
+        gasUsed: '21000',
+        cumulativeGasUsed: '21000',
+        confirmations: 10,
+      };
       const result = { id: 1 };
       jest
         .spyOn(service, 'create')
@@ -105,7 +126,11 @@ describe('ChainEventController', () => {
 
   describe('update', () => {
     it('should update a chain event', async () => {
-      const updateDto = {};
+      const updateDto = {
+        blockNumber: 12345680,
+        confirmations: 20,
+        tokenName: 'Updated Token',
+      };
       const result = { affected: 1 };
       jest
         .spyOn(service, 'update')

--- a/src/chain-event/chain-event.service.spec.ts
+++ b/src/chain-event/chain-event.service.spec.ts
@@ -71,9 +71,11 @@ describe('ChainEventService', () => {
       const createDto: CreateChainEventDto = {
         blockNumber: 12345678,
         timeStamp: new Date(),
-        transactionHash: '0x1234567890abcdef',
+        transactionHash:
+          '0x1234567890abcdef1234567890abcdef1234567890abcdef1234567890abcdef',
         nonce: 123,
-        blockHash: '0xabcdef1234567890',
+        blockHash:
+          '0x1234567890abcdef1234567890abcdef1234567890abcdef1234567890abcdef',
         from: '0x1234567890abcdef1234567890abcdef12345678',
         contractAddress: '0x1234567890abcdef1234567890abcdef12345678',
         to: '0x1234567890abcdef1234567890abcdef12345678',
@@ -87,7 +89,6 @@ describe('ChainEventService', () => {
         gasUsed: '21000',
         cumulativeGasUsed: '21000',
         confirmations: 10,
-        chainEventUniqueId: 'uniqueId123',
       };
 
       const expectedResult = { raw: [], affected: 1 };
@@ -116,9 +117,11 @@ describe('ChainEventService', () => {
         {
           blockNumber: 12345678,
           timeStamp: new Date(),
-          transactionHash: '0x1234567890abcdef1',
+          transactionHash:
+            '0x1234567890abcdef1234567890abcdef1234567890abcdef1234567890abcdef',
           nonce: 123,
-          blockHash: '0xabcdef1234567890',
+          blockHash:
+            '0x1234567890abcdef1234567890abcdef1234567890abcdef1234567890abcdef',
           from: '0x1234567890abcdef1234567890abcdef12345678',
           contractAddress: '0x1234567890abcdef1234567890abcdef12345678',
           to: '0x1234567890abcdef1234567890abcdef12345678',
@@ -132,14 +135,15 @@ describe('ChainEventService', () => {
           gasUsed: '21000',
           cumulativeGasUsed: '21000',
           confirmations: 10,
-          chainEventUniqueId: 'uniqueId123',
         },
         {
           blockNumber: 12345679,
           timeStamp: new Date(),
-          transactionHash: '0x1234567890abcdef2',
+          transactionHash:
+            '0x2234567890abcdef1234567890abcdef1234567890abcdef1234567890abcdef',
           nonce: 124,
-          blockHash: '0xabcdef1234567891',
+          blockHash:
+            '0x2234567890abcdef1234567890abcdef1234567890abcdef1234567890abcdef',
           from: '0x1234567890abcdef1234567890abcdef12345678',
           contractAddress: '0x1234567890abcdef1234567890abcdef12345678',
           to: '0x1234567890abcdef1234567890abcdef12345678',
@@ -153,7 +157,6 @@ describe('ChainEventService', () => {
           gasUsed: '21000',
           cumulativeGasUsed: '42000',
           confirmations: 9,
-          chainEventUniqueId: 'uniqueId456',
         },
       ];
 
@@ -184,14 +187,16 @@ describe('ChainEventService', () => {
           id: 1,
           blockNumber: 12345678,
           timeStamp: new Date(),
-          transactionHash: '0x1234567890abcdef',
+          transactionHash:
+            '0x1234567890abcdef1234567890abcdef1234567890abcdef1234567890abcdef',
           chainEventUniqueId: 'uniqueId123',
         },
         {
           id: 2,
           blockNumber: 12345679,
           timeStamp: new Date(),
-          transactionHash: '0x1234567890abcdef2',
+          transactionHash:
+            '0x2234567890abcdef1234567890abcdef1234567890abcdef1234567890abcdef',
           chainEventUniqueId: 'uniqueId456',
         },
       ];
@@ -212,7 +217,8 @@ describe('ChainEventService', () => {
         id,
         blockNumber: 12345678,
         timeStamp: new Date(),
-        transactionHash: '0x1234567890abcdef',
+        transactionHash:
+          '0x1234567890abcdef1234567890abcdef1234567890abcdef1234567890abcdef',
         chainEventUniqueId: 'uniqueId123',
       };
 

--- a/src/chain-event/chain-event.service.ts
+++ b/src/chain-event/chain-event.service.ts
@@ -4,6 +4,7 @@ import { Injectable } from '@nestjs/common';
 import { CreateChainEventDto } from './dto/create-chain-event.dto';
 import { UpdateChainEventDto } from './dto/update-chain-event.dto';
 import { ChainEvent } from './entities/chain-event.entity';
+import { ChainEventSchema } from './dto/chain-event.schema';
 @Injectable()
 export class ChainEventService {
   constructor(
@@ -11,11 +12,19 @@ export class ChainEventService {
     private chainEventRepository: Repository<ChainEvent>,
   ) {}
 
+  validateChainEvents(createChainEventDtos: CreateChainEventDto[]) {
+    createChainEventDtos.forEach((createChainEventDto) => {
+      ChainEventSchema.parse(createChainEventDto);
+    });
+  }
+
   async create(createChainEventDto: CreateChainEventDto) {
     return this.createMany([createChainEventDto]);
   }
 
   createMany(createChainEventDtos: CreateChainEventDto[]) {
+    this.validateChainEvents(createChainEventDtos);
+
     return this.chainEventRepository.manager
       .createQueryBuilder()
       .insert()

--- a/src/chain-event/dto/chain-event.schema.ts
+++ b/src/chain-event/dto/chain-event.schema.ts
@@ -1,0 +1,37 @@
+import { z } from 'zod';
+
+const EthereumAddressSchema = z
+  .string()
+  .length(42)
+  .regex(/^0x[a-fA-F0-9]{40}$/);
+
+const EthereumTransactionHashSchema = z
+  .string()
+  .length(66)
+  .regex(/^0x[a-fA-F0-9]{64}$/);
+
+const StringifiedNumberSchema = z.string().regex(/^[0-9]+$/);
+
+export const ChainEventDBSchema = z.object({
+  id: z.number().int().positive(),
+  blockNumber: z.number().int().positive(),
+  timeStamp: z.date(),
+  transactionHash: EthereumTransactionHashSchema,
+  nonce: z.number().int().nonnegative(),
+  blockHash: EthereumTransactionHashSchema,
+  from: EthereumAddressSchema,
+  contractAddress: EthereumAddressSchema,
+  to: EthereumAddressSchema,
+  value: StringifiedNumberSchema,
+  tokenName: z.string().max(100),
+  tokenSymbol: z.string().max(100),
+  tokenDecimal: z.number().int().min(0).max(32767), // smallint in PostgreSQL
+  transactionIndex: z.number().int().nonnegative().max(32767), // smallint in PostgreSQL
+  gas: z.number().int().positive(),
+  gasPrice: StringifiedNumberSchema,
+  gasUsed: StringifiedNumberSchema,
+  cumulativeGasUsed: StringifiedNumberSchema,
+  confirmations: z.number().int().nonnegative(),
+});
+
+export const ChainEventSchema = ChainEventDBSchema.omit({ id: true });

--- a/src/chain-event/dto/create-chain-event.dto.ts
+++ b/src/chain-event/dto/create-chain-event.dto.ts
@@ -1,1 +1,4 @@
-export class CreateChainEventDto {}
+import { createZodDto } from 'nestjs-zod';
+import { ChainEventSchema } from './chain-event.schema';
+
+export class CreateChainEventDto extends createZodDto(ChainEventSchema) {}

--- a/src/chain-event/entities/chain-event.entity.ts
+++ b/src/chain-event/entities/chain-event.entity.ts
@@ -1,7 +1,13 @@
 import { Entity, PrimaryGeneratedColumn, Column, Index } from 'typeorm';
 import { ChainEventDB } from '../types/chain-event';
-
 @Entity()
+@Index(
+  'chain_event_unique_id',
+  ['transactionHash', 'from', 'to', 'contractAddress'],
+  {
+    unique: true,
+  },
+)
 export class ChainEvent implements ChainEventDB {
   @PrimaryGeneratedColumn()
   id: number;
@@ -59,8 +65,4 @@ export class ChainEvent implements ChainEventDB {
 
   @Column({ type: 'bigint', nullable: false })
   confirmations: number;
-
-  @Column({ type: 'varchar', length: 100, nullable: false })
-  @Index({ unique: true })
-  chainEventUniqueId: string;
 }

--- a/src/chain-event/etherscan.service.spec.ts
+++ b/src/chain-event/etherscan.service.spec.ts
@@ -13,7 +13,7 @@ jest.mock('axios', () => ({
 import { Test, TestingModule } from '@nestjs/testing';
 import { ConfigService } from '@nestjs/config';
 import { EtherscanService } from './etherscan.service';
-import { ChainEventTransaction } from './types/chain-event';
+import { ChainEventTransaction } from './types/chain-event-transaction';
 
 // Define the response type for our mock
 interface MockResponse<T> {

--- a/src/chain-event/etherscan.service.ts
+++ b/src/chain-event/etherscan.service.ts
@@ -2,7 +2,7 @@ import { ConfigService } from '@nestjs/config';
 import { EtherscanConfig } from '../config/config';
 import axios, { AxiosInstance } from 'axios';
 import { Injectable } from '@nestjs/common';
-import { ChainEventTransaction } from './types/chain-event';
+import { ChainEventTransaction } from './types/chain-event-transaction';
 
 interface EtherscanRequest {
   module: 'account';

--- a/src/chain-event/types/chain-event-transaction.ts
+++ b/src/chain-event/types/chain-event-transaction.ts
@@ -1,0 +1,21 @@
+export interface ChainEventTransaction {
+  blockNumber: string;
+  timeStamp: string;
+  hash: string;
+  nonce: string;
+  blockHash: string;
+  from: string;
+  contractAddress: string;
+  to: string;
+  value: string;
+  tokenName: string;
+  tokenSymbol: string;
+  tokenDecimal: string;
+  transactionIndex: string;
+  gas: string;
+  gasPrice: string;
+  gasUsed: string;
+  cumulativeGasUsed: string;
+  input?: string;
+  confirmations: string;
+}

--- a/src/chain-event/types/chain-event.ts
+++ b/src/chain-event/types/chain-event.ts
@@ -1,43 +1,9 @@
-export interface ChainEventTransaction {
-  blockNumber: string;
-  timeStamp: string;
-  hash: string;
-  nonce: string;
-  blockHash: string;
-  from: string;
-  contractAddress: string;
-  to: string;
-  value: string;
-  tokenName: string;
-  tokenSymbol: string;
-  tokenDecimal: string;
-  transactionIndex: string;
-  gas: string;
-  gasPrice: string;
-  gasUsed: string;
-  cumulativeGasUsed: string;
-  input?: string;
-  confirmations: string;
-}
+import { z } from 'zod';
+import {
+  ChainEventDBSchema,
+  ChainEventSchema,
+} from '../dto/chain-event.schema';
 
-export type ChainEventDB = Omit<
-  ChainEventTransaction,
-  | 'timeStamp'
-  | 'blockNumber'
-  | 'nonce'
-  | 'tokenDecimal'
-  | 'transactionIndex'
-  | 'gas'
-  | 'confirmations'
-  | 'hash'
-> & {
-  timeStamp: Date;
-  blockNumber: number;
-  nonce: number;
-  tokenDecimal: number;
-  transactionIndex: number;
-  gas: number;
-  confirmations: number;
-  transactionHash: string;
-  chainEventUniqueId: string;
-};
+export type ChainEvent = z.infer<typeof ChainEventSchema>;
+
+export type ChainEventDB = z.infer<typeof ChainEventDBSchema>;

--- a/src/exchange-event/dto/create-exchange-event.ts
+++ b/src/exchange-event/dto/create-exchange-event.ts
@@ -1,0 +1,4 @@
+import { createZodDto } from 'nestjs-zod';
+import { ExchangeEventSchema } from './exchange-event.schema';
+
+export class CreateExchangeEventDto extends createZodDto(ExchangeEventSchema) {}

--- a/src/exchange-event/dto/exchange-event.schema.ts
+++ b/src/exchange-event/dto/exchange-event.schema.ts
@@ -1,0 +1,54 @@
+import { z } from 'zod';
+
+// Define reusable validators
+const TransactionIdSchema = z.string().max(100);
+const DecimalSchema = z.number().or(
+  z
+    .string()
+    .regex(/^-?\d+(\.\d+)?$/)
+    .transform(Number),
+);
+const OptionalStringSchema = z.string().max(100).optional();
+const OptionalStringArraySchema = z.array(z.string()).optional();
+
+// Main schema for use with database entities (includes ID)
+export const ExchangeEventDBSchema = z.object({
+  id: z.number().int().positive(),
+  txid: TransactionIdSchema,
+  pair: z.string().max(20),
+  time: z.date(),
+  type: z.enum(['buy', 'sell']),
+  ordertype: z.string().max(20),
+  price: DecimalSchema,
+  cost: DecimalSchema,
+  fee: DecimalSchema,
+  vol: DecimalSchema,
+  margin: DecimalSchema,
+  leverage: DecimalSchema,
+  maker: z.boolean(),
+  trade_id: z.number().int(),
+  ordertxid: TransactionIdSchema,
+  misc: z.string().max(100),
+  aclass: z.string().max(50),
+  ledgers: OptionalStringArraySchema,
+  postxid: OptionalStringSchema,
+  posstatus: OptionalStringSchema,
+  cprice: OptionalStringSchema,
+  ccost: OptionalStringSchema,
+  cfee: OptionalStringSchema,
+  cvol: OptionalStringSchema,
+  cmargin: OptionalStringSchema,
+  net: OptionalStringSchema,
+  trades: OptionalStringArraySchema,
+});
+
+// Schema without ID for creating new records
+export const ExchangeEventSchema = ExchangeEventDBSchema.omit({ id: true });
+
+// Schema for paginated response
+export const PaginatedExchangeResponseSchema = z.object({
+  results: z.array(ExchangeEventDBSchema),
+  hasNextPage: z.boolean(),
+  currentPage: z.number().int().nonnegative(),
+  resultsCount: z.number().int().nonnegative(),
+});

--- a/src/exchange-event/dto/update-exchange-event.ts
+++ b/src/exchange-event/dto/update-exchange-event.ts
@@ -1,0 +1,6 @@
+import { PartialType } from '@nestjs/mapped-types';
+import { CreateExchangeEventDto } from './create-exchange-event';
+
+export class UpdateExchangeEventDto extends PartialType(
+  CreateExchangeEventDto,
+) {}

--- a/src/exchange-event/entities/exchange-event.entity.ts
+++ b/src/exchange-event/entities/exchange-event.entity.ts
@@ -1,0 +1,69 @@
+import { Entity, PrimaryGeneratedColumn, Column, Index } from 'typeorm';
+import { ExchangeEvent as ExchangeEventDB } from '../types/exchange-event';
+
+@Entity()
+export class ExchangeEvent implements ExchangeEventDB {
+  @PrimaryGeneratedColumn()
+  id: number;
+
+  @Index({ unique: true })
+  @Column({ type: 'varchar', length: 100, nullable: false })
+  txid: string;
+
+  @Column({ type: 'varchar', length: 20, nullable: false })
+  pair: string;
+
+  @Column({ type: 'timestamptz', nullable: false })
+  time: Date;
+
+  @Column({ type: 'enum', enum: ['buy', 'sell'], nullable: false })
+  type: 'buy' | 'sell';
+
+  @Column({ type: 'varchar', length: 20, nullable: false })
+  ordertype: string;
+
+  @Column({ type: 'decimal', precision: 20, scale: 8, nullable: false })
+  price: number;
+
+  @Column({ type: 'decimal', precision: 20, scale: 8, nullable: false })
+  cost: number;
+
+  @Column({ type: 'decimal', precision: 20, scale: 8, nullable: false })
+  fee: number;
+
+  @Column({ type: 'decimal', precision: 20, scale: 8, nullable: false })
+  vol: number;
+
+  @Column({ type: 'decimal', precision: 20, scale: 8, nullable: false })
+  margin: number;
+
+  @Column({ type: 'decimal', precision: 10, scale: 2, nullable: false })
+  leverage: number;
+
+  @Column({ type: 'boolean', nullable: false })
+  maker: boolean;
+
+  @Column({ type: 'integer', nullable: false })
+  trade_id: number;
+
+  @Column({ type: 'varchar', length: 100, nullable: false })
+  ordertxid: string;
+
+  @Column({ type: 'varchar', length: 100, nullable: false })
+  misc: string;
+
+  @Column({ type: 'varchar', length: 50, nullable: false })
+  aclass: string;
+
+  @Column({ type: 'simple-array', nullable: true })
+  ledgers?: string[];
+
+  @Column({ type: 'varchar', length: 100, nullable: true })
+  postxid?: string;
+
+  @Column({ type: 'varchar', length: 50, nullable: true })
+  posstatus?: string;
+
+  @Column({ type: 'simple-array', nullable: true })
+  trades?: string[];
+}

--- a/src/exchange-event/exchange-event.controller.spec.ts
+++ b/src/exchange-event/exchange-event.controller.spec.ts
@@ -1,8 +1,7 @@
 import { Test, TestingModule } from '@nestjs/testing';
 import { ExchangeEventController } from './exchange-event.controller';
 import { KrakenService } from './kraken.service';
-import { KrakenTradeTransaction } from './types/exchange-transaction';
-
+import { ExchangeEvent } from './types/exchange-event';
 describe('ExchangeEventController', () => {
   let controller: ExchangeEventController;
 
@@ -31,7 +30,7 @@ describe('ExchangeEventController', () => {
 
   describe('getClosedTrades', () => {
     it('should return all closed trades from Kraken service', async () => {
-      const mockTrades: KrakenTradeTransaction[] = [
+      const mockTrades: ExchangeEvent[] = [
         {
           txid: 'TXID1',
           aclass: 'forex',
@@ -97,7 +96,7 @@ describe('ExchangeEventController', () => {
 
   describe('getSellTrades', () => {
     it('should return only sell trades from Kraken service', async () => {
-      const mockSellTrades: KrakenTradeTransaction[] = [
+      const mockSellTrades: ExchangeEvent[] = [
         {
           txid: 'TXID1',
           aclass: 'forex',

--- a/src/exchange-event/exchange-event.module.ts
+++ b/src/exchange-event/exchange-event.module.ts
@@ -1,10 +1,15 @@
 import { Module } from '@nestjs/common';
 import { ExchangeEventController } from './exchange-event.controller';
 import { KrakenService } from './kraken.service';
+import { ExchangeEventService } from './exchange-event.service';
+import { TypeOrmModule } from '@nestjs/typeorm';
+import { ExchangeEvent } from './entities/exchange-event.entity';
+import { ConfigModule } from '@nestjs/config';
 
 @Module({
+  imports: [ConfigModule, TypeOrmModule.forFeature([ExchangeEvent])],
   controllers: [ExchangeEventController],
-  providers: [KrakenService],
-  exports: [KrakenService],
+  providers: [KrakenService, ExchangeEventService],
+  exports: [],
 })
 export class ExchangeEventModule {}

--- a/src/exchange-event/exchange-event.service.ts
+++ b/src/exchange-event/exchange-event.service.ts
@@ -2,6 +2,9 @@ import { Injectable } from '@nestjs/common';
 import { InjectRepository } from '@nestjs/typeorm';
 import { Repository } from 'typeorm';
 import { ExchangeEvent } from './entities/exchange-event.entity';
+import { CreateExchangeEventDto } from './dto/create-exchange-event';
+import { UpdateExchangeEventDto } from './dto/update-exchange-event';
+import { ExchangeEventSchema } from './dto/exchange-event.schema';
 
 @Injectable()
 export class ExchangeEventService {
@@ -10,11 +13,18 @@ export class ExchangeEventService {
     private readonly exchangeEventRepository: Repository<ExchangeEvent>,
   ) {}
 
-  create(exchangeEvent: ExchangeEvent) {
+  private validateExchangeEvents(exchangeEvents: CreateExchangeEventDto[]) {
+    exchangeEvents.forEach((exchangeEvent) => {
+      ExchangeEventSchema.parse(exchangeEvent);
+    });
+  }
+
+  public create(exchangeEvent: CreateExchangeEventDto) {
     return this.createMany([exchangeEvent]);
   }
 
-  createMany(exchangeEvents: ExchangeEvent[]) {
+  public createMany(exchangeEvents: CreateExchangeEventDto[]) {
+    this.validateExchangeEvents(exchangeEvents);
     return this.exchangeEventRepository.manager
       .createQueryBuilder()
       .insert()
@@ -24,23 +34,23 @@ export class ExchangeEventService {
       .execute();
   }
 
-  findAll() {
+  public findAll() {
     return this.exchangeEventRepository.find();
   }
 
-  findOne(id: number) {
+  public findOne(id: number) {
     return this.exchangeEventRepository.findOne({ where: { id } });
   }
 
-  update(id: number, partialEntity: Partial<ExchangeEvent>) {
+  public update(id: number, partialEntity: UpdateExchangeEventDto) {
     return this.exchangeEventRepository.update(id, partialEntity);
   }
 
-  remove(id: number) {
+  public remove(id: number) {
     return this.exchangeEventRepository.delete(id);
   }
 
-  findLatestExchangeEventTimestamp() {
+  public findLatestExchangeEventTimestamp() {
     return this.exchangeEventRepository.findOne({
       order: { time: 'DESC' },
     });

--- a/src/exchange-event/exchange-event.service.ts
+++ b/src/exchange-event/exchange-event.service.ts
@@ -1,0 +1,48 @@
+import { Injectable } from '@nestjs/common';
+import { InjectRepository } from '@nestjs/typeorm';
+import { Repository } from 'typeorm';
+import { ExchangeEvent } from './entities/exchange-event.entity';
+
+@Injectable()
+export class ExchangeEventService {
+  constructor(
+    @InjectRepository(ExchangeEvent)
+    private readonly exchangeEventRepository: Repository<ExchangeEvent>,
+  ) {}
+
+  create(exchangeEvent: ExchangeEvent) {
+    return this.createMany([exchangeEvent]);
+  }
+
+  createMany(exchangeEvents: ExchangeEvent[]) {
+    return this.exchangeEventRepository.manager
+      .createQueryBuilder()
+      .insert()
+      .into(ExchangeEvent)
+      .values(exchangeEvents)
+      .orIgnore()
+      .execute();
+  }
+
+  findAll() {
+    return this.exchangeEventRepository.find();
+  }
+
+  findOne(id: number) {
+    return this.exchangeEventRepository.findOne({ where: { id } });
+  }
+
+  update(id: number, partialEntity: Partial<ExchangeEvent>) {
+    return this.exchangeEventRepository.update(id, partialEntity);
+  }
+
+  remove(id: number) {
+    return this.exchangeEventRepository.delete(id);
+  }
+
+  findLatestExchangeEventTimestamp() {
+    return this.exchangeEventRepository.findOne({
+      order: { time: 'DESC' },
+    });
+  }
+}

--- a/src/exchange-event/kraken.service.spec.ts
+++ b/src/exchange-event/kraken.service.spec.ts
@@ -3,8 +3,8 @@ import { ConfigService } from '@nestjs/config';
 import { KrakenService } from './kraken.service';
 import { PaginatedExchangeResponse } from './types/exchange-event';
 import axios, { AxiosInstance } from 'axios';
-import { KrakenTradeTransactionRaw } from './types/exchange-transaction';
 import { ExchangeEvent } from './types/exchange-event';
+import { KrakenTradeTransactionDictionary } from './types/kraken-api-responses';
 // Mock axios
 jest.mock('axios');
 const mockAxios = axios as jest.Mocked<typeof axios>;
@@ -50,7 +50,7 @@ describe('KrakenService', () => {
   });
 
   describe('getClosedTrades', () => {
-    const mockTrades: Record<string, KrakenTradeTransactionRaw> = {
+    const mockTrades: KrakenTradeTransactionDictionary = {
       TXID1: {
         aclass: 'forex',
         leverage: '0',

--- a/src/exchange-event/kraken.service.spec.ts
+++ b/src/exchange-event/kraken.service.spec.ts
@@ -3,11 +3,8 @@ import { ConfigService } from '@nestjs/config';
 import { KrakenService } from './kraken.service';
 import { PaginatedExchangeResponse } from './types/exchange-event';
 import axios, { AxiosInstance } from 'axios';
-import {
-  KrakenTradeTransaction,
-  KrakenTradeTransactionRaw,
-} from './types/exchange-transaction';
-
+import { KrakenTradeTransactionRaw } from './types/exchange-transaction';
+import { ExchangeEvent } from './types/exchange-event';
 // Mock axios
 jest.mock('axios');
 const mockAxios = axios as jest.Mocked<typeof axios>;
@@ -90,20 +87,20 @@ describe('KrakenService', () => {
       },
     };
 
-    const expectedTrades: KrakenTradeTransaction[] = Object.entries(
-      mockTrades,
-    ).map(([txid, rawTrade]) => ({
-      txid,
-      ...rawTrade,
-      leverage: +rawTrade.leverage,
-      time: new Date(rawTrade.time * 1000),
-      price: +rawTrade.price,
-      cost: +rawTrade.cost,
-      fee: +rawTrade.fee,
-      vol: +rawTrade.vol,
-      margin: +rawTrade.margin,
-      misc: rawTrade.misc,
-    }));
+    const expectedTrades: ExchangeEvent[] = Object.entries(mockTrades).map(
+      ([txid, rawTrade]) => ({
+        txid,
+        ...rawTrade,
+        leverage: +rawTrade.leverage,
+        time: new Date(rawTrade.time * 1000),
+        price: +rawTrade.price,
+        cost: +rawTrade.cost,
+        fee: +rawTrade.fee,
+        vol: +rawTrade.vol,
+        margin: +rawTrade.margin,
+        misc: rawTrade.misc,
+      }),
+    );
 
     it('should call Kraken API with correct parameters without start/end', async () => {
       mockClient.post.mockResolvedValueOnce({
@@ -169,7 +166,7 @@ describe('KrakenService', () => {
 
   describe('getSellTrades', () => {
     it('should filter and return only sell trades', async () => {
-      const mockTrades: KrakenTradeTransaction[] = [
+      const mockTrades: ExchangeEvent[] = [
         {
           txid: 'TXID1',
           aclass: 'forex',
@@ -227,15 +224,14 @@ describe('KrakenService', () => {
       ];
 
       // Mock the getClosedTrades method to return our test data
-      const mockResponse: PaginatedExchangeResponse<KrakenTradeTransaction[]> =
-        {
-          results: Object.values(mockTrades).filter(
-            (trade) => trade.type === 'sell',
-          ),
-          hasNextPage: false,
-          currentPage: 1,
-          resultsCount: 2,
-        };
+      const mockResponse: PaginatedExchangeResponse<ExchangeEvent[]> = {
+        results: Object.values(mockTrades).filter(
+          (trade) => trade.type === 'sell',
+        ),
+        hasNextPage: false,
+        currentPage: 1,
+        resultsCount: 2,
+      };
 
       jest.spyOn(service, 'getClosedTrades').mockResolvedValue(mockResponse);
 

--- a/src/exchange-event/kraken.service.ts
+++ b/src/exchange-event/kraken.service.ts
@@ -5,8 +5,11 @@ import { Injectable, Logger } from '@nestjs/common';
 import * as crypto from 'crypto';
 import * as querystring from 'querystring';
 import { PaginatedExchangeResponse } from './types/exchange-event';
-import { KrakenTradeTransactionRaw } from './types/exchange-transaction';
 import { ExchangeEvent } from './types/exchange-event';
+import {
+  KrakenTradeTransactionDictionary,
+  KrakenTradeTransactionResponse,
+} from './types/kraken-api-responses';
 
 interface KrakenResponse<T> {
   error: string[];
@@ -102,7 +105,7 @@ export class KrakenService {
    * @returns The trade transaction array
    */
   private convertTradeTransactionRawToTradeTransaction(
-    rawTradeDictionary: Record<string, KrakenTradeTransactionRaw>,
+    rawTradeDictionary: KrakenTradeTransactionDictionary,
   ): ExchangeEvent[] {
     return Object.entries(rawTradeDictionary).map(([txid, rawTrade]) => ({
       ...rawTrade,
@@ -165,10 +168,10 @@ export class KrakenService {
       params.ofs = offset;
     }
 
-    const response = await this.sendRequest<{
-      trades: Record<string, KrakenTradeTransactionRaw>;
-      count: number;
-    }>('0/private/TradesHistory', params);
+    const response = await this.sendRequest<KrakenTradeTransactionResponse>(
+      '0/private/TradesHistory',
+      params,
+    );
 
     const tradeTransactions = this.convertTradeTransactionRawToTradeTransaction(
       response.result.trades,

--- a/src/exchange-event/kraken.service.ts
+++ b/src/exchange-event/kraken.service.ts
@@ -5,10 +5,8 @@ import { Injectable, Logger } from '@nestjs/common';
 import * as crypto from 'crypto';
 import * as querystring from 'querystring';
 import { PaginatedExchangeResponse } from './types/exchange-event';
-import {
-  KrakenTradeTransaction,
-  KrakenTradeTransactionRaw,
-} from './types/exchange-transaction';
+import { KrakenTradeTransactionRaw } from './types/exchange-transaction';
+import { ExchangeEvent } from './types/exchange-event';
 
 interface KrakenResponse<T> {
   error: string[];
@@ -105,7 +103,7 @@ export class KrakenService {
    */
   private convertTradeTransactionRawToTradeTransaction(
     rawTradeDictionary: Record<string, KrakenTradeTransactionRaw>,
-  ): KrakenTradeTransaction[] {
+  ): ExchangeEvent[] {
     return Object.entries(rawTradeDictionary).map(([txid, rawTrade]) => ({
       ...rawTrade,
       txid,
@@ -152,7 +150,7 @@ export class KrakenService {
     start?: number,
     end?: number,
     offset?: number,
-  ): Promise<PaginatedExchangeResponse<KrakenTradeTransaction[]>> {
+  ): Promise<PaginatedExchangeResponse<ExchangeEvent[]>> {
     const params: Record<string, any> = {};
 
     if (start) {
@@ -193,7 +191,7 @@ export class KrakenService {
   public async getSellTrades(
     start?: number,
     end?: number,
-  ): Promise<PaginatedExchangeResponse<KrakenTradeTransaction[]>> {
+  ): Promise<PaginatedExchangeResponse<ExchangeEvent[]>> {
     const allTrades = await this.getClosedTrades(start, end);
 
     // Filter to only include sell trades

--- a/src/exchange-event/types/exchange-event.ts
+++ b/src/exchange-event/types/exchange-event.ts
@@ -1,23 +1,17 @@
-import { KrakenTradeTransactionRaw } from './exchange-transaction';
+import { z } from 'zod';
+import {
+  ExchangeEventDBSchema,
+  ExchangeEventSchema,
+} from '../dto/exchange-event.schema';
 
-export interface PaginatedExchangeResponse<T> {
+// New type definitions using Zod
+export type ExchangeEvent = z.infer<typeof ExchangeEventSchema>;
+
+export type ExchangeEventDB = z.infer<typeof ExchangeEventDBSchema>;
+
+export type PaginatedExchangeResponse<T> = {
   results: T;
   hasNextPage: boolean;
   currentPage: number;
   resultsCount: number;
-}
-
-export interface ExchangeEvent
-  extends Omit<
-    KrakenTradeTransactionRaw,
-    'time' | 'price' | 'cost' | 'fee' | 'vol' | 'margin' | 'leverage'
-  > {
-  txid: string;
-  time: Date;
-  price: number;
-  cost: number;
-  fee: number;
-  vol: number;
-  margin: number;
-  leverage: number;
-}
+};

--- a/src/exchange-event/types/exchange-event.ts
+++ b/src/exchange-event/types/exchange-event.ts
@@ -1,6 +1,23 @@
+import { KrakenTradeTransactionRaw } from './exchange-transaction';
+
 export interface PaginatedExchangeResponse<T> {
   results: T;
   hasNextPage: boolean;
   currentPage: number;
   resultsCount: number;
+}
+
+export interface ExchangeEvent
+  extends Omit<
+    KrakenTradeTransactionRaw,
+    'time' | 'price' | 'cost' | 'fee' | 'vol' | 'margin' | 'leverage'
+  > {
+  txid: string;
+  time: Date;
+  price: number;
+  cost: number;
+  fee: number;
+  vol: number;
+  margin: number;
+  leverage: number;
 }

--- a/src/exchange-event/types/exchange-transaction.ts
+++ b/src/exchange-event/types/exchange-transaction.ts
@@ -26,21 +26,6 @@ export interface KrakenTradeTransactionRaw {
   trades?: string[];
 }
 
-export interface KrakenTradeTransaction
-  extends Omit<
-    KrakenTradeTransactionRaw,
-    'time' | 'price' | 'cost' | 'fee' | 'vol' | 'margin' | 'leverage'
-  > {
-  txid: string;
-  time: Date;
-  price: number;
-  cost: number;
-  fee: number;
-  vol: number;
-  margin: number;
-  leverage: number;
-}
-
 export interface PaginatedExchangeResponse<T> {
   currentPage: number;
   hasNextPage: boolean;

--- a/src/exchange-event/types/exchange-transaction.ts
+++ b/src/exchange-event/types/exchange-transaction.ts
@@ -1,31 +1,3 @@
-export interface KrakenTradeTransactionRaw {
-  ordertxid: string;
-  pair: string;
-  time: number;
-  type: 'buy' | 'sell';
-  ordertype: string;
-  price: string;
-  cost: string;
-  fee: string;
-  vol: string;
-  margin: string;
-  misc: string;
-  aclass: string;
-  leverage: string;
-  trade_id: number;
-  maker: boolean;
-  ledgers?: string[];
-  postxid?: string;
-  posstatus?: string;
-  cprice?: string;
-  ccost?: string;
-  cfee?: string;
-  cvol?: string;
-  cmargin?: string;
-  net?: string;
-  trades?: string[];
-}
-
 export interface PaginatedExchangeResponse<T> {
   currentPage: number;
   hasNextPage: boolean;

--- a/src/exchange-event/types/kraken-api-responses.ts
+++ b/src/exchange-event/types/kraken-api-responses.ts
@@ -1,0 +1,25 @@
+import { ExchangeEvent } from './exchange-event';
+
+export interface KrakenTradeTransaction
+  extends Omit<
+    ExchangeEvent,
+    'time' | 'price' | 'cost' | 'fee' | 'vol' | 'margin' | 'leverage'
+  > {
+  time: number;
+  price: string;
+  cost: string;
+  fee: string;
+  vol: string;
+  margin: string;
+  leverage: string;
+}
+
+export type KrakenTradeTransactionDictionary = Record<
+  string,
+  Omit<KrakenTradeTransaction, 'txid'>
+>;
+
+export interface KrakenTradeTransactionResponse {
+  count: number;
+  trades: KrakenTradeTransactionDictionary;
+}


### PR DESCRIPTION
## Description

This PR adds schema validation for chain events using Zod and nestjs-zod. It implements proper data validation for Ethereum transaction details like addresses, transaction hashes, and numeric values to ensure data integrity throughout the application.

## Key Changes

- Added `zod` and `nestjs-zod` packages as dependencies
- Created a Zod schema for chain events with strict format validation:
  - Ethereum addresses must be 42 characters and match regex `^0x[a-fA-F0-9]{40}$`
  - Transaction and block hashes must be 66 characters and match regex `^0x[a-fA-F0-9]{64}$`
  - Numeric values stored as strings must match regex `^[0-9]+$`
- Integrated `ZodValidationPipe` globally in the application
- Added validation to `ChainEventService` to validate all chain events before database operations
- Created a `CreateChainEventDto` class that extends the Zod schema
- Refactored entity and type interfaces for better type safety
- Updated tests to use properly formatted test data that passes validation
- Added a composite unique index on chain events to prevent duplicates

## Database Schema Changes

- Removed `chainEventUniqueId` column from `chain_event` table
- Added a composite unique index on `transactionHash`, `from`, `to`, and `contractAddress` columns

## How to Test

1. Run `npm test` to verify all tests pass
2. Test API endpoints with both valid and invalid data to confirm validation is working correctly
3. Verify that duplicate chain events are properly rejected

## Additional Notes

- All existing tests have been updated to pass with the new validation rules
- Added specific Zod schemas for different Ethereum data types to maintain consistency
- The validation pipe is globally applied, so all endpoints that use DTOs will now benefit from automatic validation
